### PR TITLE
Added aarch64 as a recognizable CPU type

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -250,7 +250,7 @@ case $basic_machine in
 	| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
 	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
 	| am33_2.0 \
-	| arc | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
+	| arc | aarch64 | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
 	| bfin \
 	| c4x | clipper \
 	| d10v | d30v | dlx | dsp16xx \


### PR DESCRIPTION
I don't know enough about net-snmp to tell if this is enough to make Arm64 CPU family work correctly but it will at least let me build the software. 